### PR TITLE
Adjust regex to match without trailing "//"

### DIFF
--- a/OpenURL.omnifocusjs/Resources/openurl.js
+++ b/OpenURL.omnifocusjs/Resources/openurl.js
@@ -4,7 +4,7 @@
     const lib = this.openURLlib
     const task = selection.tasks[0] || selection.projects[0].task
 
-    const regex = /\b\S*\:\/{2,3}[a-zA-Z./?_=\-\&%0-9:~#\[\]!\$'\(\)\*\+]*(\b)?/gm // eslint-disable-line
+    const regex = /\b\S*\:(?!\s|\d)(\/{2,3})?[a-zA-Z.@/?_=\-\&%0-9~#\[\]!\$'\(\)\*\+]*(\b)?/gm // eslint-disable-line
 
     const urls = [...task.note.matchAll(regex)].map(match => match[0])
 


### PR DESCRIPTION
This might break things I'm unaware of so feel free to decline this. 😊 I noticed that while moving Mail messages into OF it creates URLs like:

`message:%IDENTIFIER%3E`

The problem is that the current regex requires there to be a trailing `//` in that URL:

`message://%IDENTIFIER%3E`

I could just add those, but when I'm dragging 4-5 emails into OF, it becomes a chore to go through each one and modify.

Also I found that my modification then would match on times like `08:00:00`, so I made another change so that `:` can't have a digit directly after it. I don't know of any URLs that do this, but that _could_ cause some unforeseen issue.

To sum up:

- I wrapped `\/{2,3}` in a conditional so that `//` doesn't have to exist in the URL
- I added a negative lookahead so that the `:` cannot have a space or a digit directly after it
- I also added `@` to the approved characters as Mail likes to append the account type at the end `@gmail` for instance